### PR TITLE
Add font-display descriptor to improve performance

### DIFF
--- a/src/scss/components/_fonts.scss
+++ b/src/scss/components/_fonts.scss
@@ -7,6 +7,7 @@
         url('../fonts/OpenSans-Regular.ttf') format('truetype');
     font-weight: normal;
     font-style: normal;
+    font-display: fallback;
 }
 
 @font-face {
@@ -18,6 +19,7 @@
         url('../fonts/OpenSans-Bold.ttf') format('truetype');
     font-weight: bold;
     font-style: normal;
+    font-display: fallback;
 }
 
 @font-face {
@@ -29,6 +31,7 @@
         url('../fonts/OpenSans-ExtraBold.ttf') format('truetype');
     font-weight: 800;
     font-style: normal;
+    font-display: fallback;
 }
 
 @font-face {
@@ -40,6 +43,7 @@
         url('../fonts/OpenSans-Light.ttf') format('truetype');
     font-weight: 300;
     font-style: normal;
+    font-display: fallback;
 }
 
 @font-face {
@@ -51,4 +55,5 @@
         url('../fonts/OpenSans-SemiBold.ttf') format('truetype');
     font-weight: 600;
     font-style: normal;
+    font-display: fallback;
 }


### PR DESCRIPTION
## Related to Issue
Fixes #3 

## Description
This change increases the Google PageSpeed Insights score for Mobile from 93 to 95.  Desktop is still 100.  📣 

## How Has This Been Tested?
Local development environment and on dnnsoftware.org.

## Screenshots (if appropriate):
n/a

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
