### PR TITLE
Hovered submenu is same color as header

### DIFF
--- a/menus/main/MainMenu.txt
+++ b/menus/main/MainMenu.txt
@@ -12,7 +12,7 @@
       [/?]
       
       [?NODE]
-        <ul>
+        <ul class="shadow-lg mb-5 rounded">
           [*>NODE]
         </ul>
       [/?]
@@ -29,7 +29,7 @@
       [/?]
       
       [?NODE]
-        <ul>
+        <ul class="shadow-lg mb-5 rounded">
           [*>NODE]
         </ul>
       [/?]


### PR DESCRIPTION
## Related to Issue
Resolves #55 

## Description
Hovered submenu is same color as header.  This adds a nice drop shadow to the submenus.

## How Has This Been Tested?
Local development environment.

## Screenshots (if appropriate):
n/a

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
