### PR TITLE
Improve styling for when replying to user messages

### DIFF
--- a/src/scss/sections/_messaging.scss
+++ b/src/scss/sections/_messaging.scss
@@ -1,0 +1,11 @@
+.DnnModule-Messaging-Details .smListings .ListCol-1 {
+    width: 10%;
+}
+.DnnModule-Messaging-Details .smListings .ListCol-2 {
+    width: 65%;
+}
+
+.DnnModule-Messaging-Details textarea#replyMessage{
+    height:15em;
+    width:100%;
+}

--- a/src/scss/sections/_sections.scss
+++ b/src/scss/sections/_sections.scss
@@ -2,3 +2,4 @@
 @import 'footer';
 @import 'bannerpane';
 @import 'activity-feed';
+@import 'messaging';


### PR DESCRIPTION
## Related to Issue
Resolves #66 
Resolves #72 

## Description
Styling improved for replying to user messages.

## How Has This Been Tested?
Local development environment.

## Screenshots (if appropriate):
<img width="727" alt="Screenshot 2019-09-30 01 12 22" src="https://user-images.githubusercontent.com/4568451/65851149-da736e00-e31f-11e9-817a-4abc0c64c9c5.png">

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
