### PR TITLE
Blog List image width fix

### DIFF
--- a/Templates/Blog/CommunityBlog/ListImage.html
+++ b/Templates/Blog/CommunityBlog/ListImage.html
@@ -1,5 +1,5 @@
 <picture>
-    <img title="[post:localizedtitle]"
-        src="[settings:imagehandlerpath]?TabId=[module:tabid]&ModuleId=[module:moduleid]&Blog=[Post:blogid]&Post=[Post:contentitemid]&w=270&h=152&c=0&key=[Post:image]"
+    <img title="[post:localizedtitle]" alt="[post:localizedtitle]"
+        src="[settings:imagehandlerpath]?TabId=[module:tabid]&ModuleId=[module:moduleid]&Blog=[Post:blogid]&Post=[Post:contentitemid]&w=500&h=500&c=0&key=[Post:image]"
         class="img-fluid dnnc-blog-img" />
 </picture>


### PR DESCRIPTION
- Fixed the width of the images in "list view"
- As the image didn't have a valid alt attribute I fixed that too
fixes #140

![image](https://github.com/DNNCommunity/DNNCommunityTheme/assets/8999382/3016a56c-ff1b-4e7f-adfb-911b8a7aff89)
