### PR TITLE
Remove non-exisent EnableTheming="true"  from Search SKO

### DIFF
--- a/includes/top-bar-login-search.ascx
+++ b/includes/top-bar-login-search.ascx
@@ -7,7 +7,7 @@
 			<dnn:LOGIN ID="dnnLogin" CssClass="login-link" runat="server" LegacyMode="false" />
 		</div>
 		<div class="search-wrap">
-			<dnn:SEARCH ID="dnnSearch" runat="server" ShowSite="false" ShowWeb="false" EnableTheming="true" Submit='<i class="fa fa-search"></i>' CssClass="SearchButton" />
+			<dnn:SEARCH ID="dnnSearch" runat="server" ShowSite="false" ShowWeb="false" Submit='<i class="fa fa-search"></i>' CssClass="SearchButton" />
 
 		</div>
 	</div>


### PR DESCRIPTION
SKO has an attribute that does nothing.
Gets in the way when converting to MVC pipeline (where attributed that don't exist cause an error)